### PR TITLE
Feature ETP-2204: Add MemoryTool and test

### DIFF
--- a/tests/test_memory_tool.py
+++ b/tests/test_memory_tool.py
@@ -1,0 +1,659 @@
+"""
+Test suite for MemoryTool
+
+This module contains comprehensive unit tests for the MemoryTool class,
+covering all CRUD operations (Create, Read, Update, Delete) with proper
+mocking of dependencies including ThreadContext and vector database operations.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.MemoryTool import MemoryTool, MemoryToolInput, validate_and_process_input
+
+
+@pytest.fixture
+def setup_tool():
+    """Create a MemoryTool instance for testing."""
+    return MemoryTool()
+
+
+@pytest.fixture
+def mock_context_data():
+    """Mock context data with assistant and user IDs."""
+    return {"assistant_id": "test_assistant_123", "ad_user_id": "test_user_456"}
+
+
+@pytest.fixture
+def mock_vector_store():
+    """Create a mock vector store for testing."""
+    mock_store = MagicMock()
+    mock_store.add_documents = MagicMock()
+    mock_store.similarity_search = MagicMock()
+    mock_store.get = MagicMock()
+    mock_store.update_documents = MagicMock()
+    mock_store.delete = MagicMock()
+    return mock_store
+
+
+@pytest.fixture
+def sample_memory_content():
+    """Sample memory content for testing."""
+    return "Remember to call John tomorrow at 3 PM about the project."
+
+
+@pytest.fixture
+def sample_memory_id():
+    """Sample memory ID for testing."""
+    return "mem_12345-67890-abcdef"
+
+
+class TestMemoryToolInput:
+    """Test cases for MemoryToolInput validation."""
+
+    def test_valid_add_input(self):
+        """Test valid input for add operation."""
+        input_data = MemoryToolInput(mode="add", memory="Test memory")
+        assert input_data.mode == "add"
+        assert input_data.memory == "Test memory"
+        assert input_data.query is None
+        assert input_data.memory_id is None
+        assert input_data.k == 3
+
+    def test_valid_search_input(self):
+        """Test valid input for search operation."""
+        input_data = MemoryToolInput(mode="search", query="test query", k=5)
+        assert input_data.mode == "search"
+        assert input_data.query == "test query"
+        assert input_data.k == 5
+        assert input_data.memory is None
+        assert input_data.memory_id is None
+
+    def test_valid_update_input(self):
+        """Test valid input for update operation."""
+        input_data = MemoryToolInput(
+            mode="update", memory="Updated content", memory_id="mem_123"
+        )
+        assert input_data.mode == "update"
+        assert input_data.memory == "Updated content"
+        assert input_data.memory_id == "mem_123"
+        assert input_data.query is None
+
+    def test_valid_delete_input(self):
+        """Test valid input for delete operation."""
+        input_data = MemoryToolInput(mode="delete", memory_id="mem_123")
+        assert input_data.mode == "delete"
+        assert input_data.memory_id == "mem_123"
+        assert input_data.memory is None
+        assert input_data.query is None
+
+
+class TestValidateAndProcessInput:
+    """Test cases for input validation function."""
+
+    def test_valid_add_mode(self):
+        """Test validation for add mode."""
+        params = {"mode": "add", "memory": "Test memory", "k": 5}
+        mode, memory, query, memory_id, k = validate_and_process_input(params)
+        assert mode == "add"
+        assert memory == "Test memory"
+        assert query is None
+        assert memory_id is None
+        assert k == 5
+
+    def test_valid_search_mode(self):
+        """Test validation for search mode."""
+        params = {"mode": "search", "query": "test query"}
+        mode, _, query, _, k = validate_and_process_input(params)
+        assert mode == "search"
+        assert query == "test query"
+        assert k == 3  # default value
+
+    def test_invalid_mode(self):
+        """Test validation with invalid mode."""
+        params = {"mode": "invalid_mode"}
+        with pytest.raises(ValueError) as exc_info:
+            validate_and_process_input(params)
+        assert "Invalid mode 'invalid_mode'" in str(exc_info.value)
+
+    def test_default_k_value(self):
+        """Test default k value when not provided."""
+        params = {"mode": "search", "query": "test"}
+        _, _, _, _, k = validate_and_process_input(params)
+        assert k == 3
+
+
+class TestMemoryToolAdd:
+    """Test cases for add operation."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    @patch("tools.MemoryTool.uuid.uuid1")
+    def test_add_success(
+        self,
+        mock_uuid,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_content,
+    ):
+        """Test successful memory addition."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+        mock_uuid.return_value = "generated_uuid_123"
+
+        # Test parameters
+        input_params = {"mode": "add", "memory": sample_memory_content}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "result" in result
+        assert "Memory added for user_id test_user_456" in result["result"]
+        assert "generated_uuid_123" in result["result"]
+        mock_vector_store.add_documents.assert_called_once()
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_add_missing_memory(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test add operation with missing memory content."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Test parameters
+        input_params = {"mode": "add"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert "The 'memory' parameter is required for 'add' mode" in result["error"]
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    def test_add_missing_context(self, mock_get_data, setup_tool):
+        """Test add operation with missing context variables."""
+        # Setup mock to return None for context variables
+        mock_get_data.return_value = None
+
+        # Test parameters
+        input_params = {"mode": "add", "memory": "Test memory"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert "assistant_id or ad_user_id not found in Payload" in result["error"]
+
+
+class TestMemoryToolSearch:
+    """Test cases for search operation."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_search_success(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test successful memory search."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock search results
+        mock_doc1 = MagicMock()
+        mock_doc1.page_content = "Memory about meeting"
+        mock_doc1.metadata = {"memory_id": "mem_123"}
+
+        mock_doc2 = MagicMock()
+        mock_doc2.page_content = "Memory about call"
+        mock_doc2.metadata = {"memory_id": "mem_456"}
+
+        mock_vector_store.similarity_search.return_value = [mock_doc1, mock_doc2]
+
+        # Test parameters
+        input_params = {"mode": "search", "query": "meeting", "k": 2}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "result" in result
+        assert "Memory about meeting (memory_id: mem_123)" in result["result"]
+        assert "Memory about call (memory_id: mem_456)" in result["result"]
+        mock_vector_store.similarity_search.assert_called_once_with(
+            query="meeting", k=2, filter={"user_id": "test_user_456"}
+        )
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_search_no_results(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test search operation with no results."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+        mock_vector_store.similarity_search.return_value = []
+
+        # Test parameters
+        input_params = {"mode": "search", "query": "nonexistent", "k": 3}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "result" in result
+        assert (
+            "No memories found for user_id test_user_456 with query: nonexistent"
+            in result["result"]
+        )
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_search_missing_query(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test search operation with missing query."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Test parameters
+        input_params = {"mode": "search", "k": 3}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert "The 'query' parameter is required for 'search' mode" in result["error"]
+
+
+class TestMemoryToolUpdate:
+    """Test cases for update operation."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_update_success(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_id,
+    ):
+        """Test successful memory update."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock existing memory
+        mock_vector_store.get.return_value = {
+            "ids": [sample_memory_id],
+            "metadatas": [{"user_id": "test_user_456", "memory_id": sample_memory_id}],
+        }
+
+        # Test parameters
+        input_params = {
+            "mode": "update",
+            "memory_id": sample_memory_id,
+            "memory": "Updated memory content",
+        }
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "result" in result
+        assert "Memory updated for user_id test_user_456" in result["result"]
+        assert "Updated memory content" in result["result"]
+        mock_vector_store.update_documents.assert_called_once()
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_update_memory_not_found(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_id,
+    ):
+        """Test update operation when memory doesn't exist."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock no existing memory
+        mock_vector_store.get.return_value = {"ids": [], "metadatas": []}
+
+        # Test parameters
+        input_params = {
+            "mode": "update",
+            "memory_id": sample_memory_id,
+            "memory": "Updated content",
+        }
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert f"No memory found with memory_id {sample_memory_id}" in result["error"]
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_update_wrong_user(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_id,
+    ):
+        """Test update operation when memory belongs to different user."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock memory belonging to different user
+        mock_vector_store.get.return_value = {
+            "ids": [sample_memory_id],
+            "metadatas": [{"user_id": "different_user", "memory_id": sample_memory_id}],
+        }
+
+        # Test parameters
+        input_params = {
+            "mode": "update",
+            "memory_id": sample_memory_id,
+            "memory": "Updated content",
+        }
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert f"No memory found with memory_id {sample_memory_id}" in result["error"]
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_update_missing_parameters(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test update operation with missing parameters."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Test parameters - missing memory_id
+        input_params = {"mode": "update", "memory": "Updated content"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert (
+            "Both 'memory_id' and 'memory' are required for 'update' mode"
+            in result["error"]
+        )
+
+
+class TestMemoryToolDelete:
+    """Test cases for delete operation."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_delete_success(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_id,
+    ):
+        """Test successful memory deletion."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock existing memory
+        mock_vector_store.get.return_value = {
+            "ids": [sample_memory_id],
+            "metadatas": [{"user_id": "test_user_456", "memory_id": sample_memory_id}],
+        }
+
+        # Test parameters
+        input_params = {"mode": "delete", "memory_id": sample_memory_id}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "result" in result
+        assert (
+            f"Memory with memory_id {sample_memory_id} deleted for user_id test_user_456"
+            in result["result"]
+        )
+        mock_vector_store.delete.assert_called_once_with(ids=[sample_memory_id])
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_delete_memory_not_found(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+        sample_memory_id,
+    ):
+        """Test delete operation when memory doesn't exist."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Mock no existing memory
+        mock_vector_store.get.return_value = {"ids": [], "metadatas": []}
+
+        # Test parameters
+        input_params = {"mode": "delete", "memory_id": sample_memory_id}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert f"No memory found with memory_id {sample_memory_id}" in result["error"]
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_delete_missing_memory_id(
+        self,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test delete operation with missing memory_id."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+
+        # Test parameters
+        input_params = {"mode": "delete"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert (
+            "The 'memory_id' parameter is required for 'delete' mode" in result["error"]
+        )
+
+
+class TestMemoryToolErrorHandling:
+    """Test cases for error handling."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    def test_vector_store_exception(
+        self, mock_get_vector_store, mock_get_data, setup_tool, mock_context_data
+    ):
+        """Test handling of vector store exceptions."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.side_effect = Exception("Database connection failed")
+
+        # Test parameters
+        input_params = {"mode": "add", "memory": "Test memory"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert "Error in MemoryTool: Database connection failed" in result["error"]
+
+    def test_invalid_mode_error(self, setup_tool):
+        """Test handling of invalid mode."""
+        # Test parameters
+        input_params = {"mode": "invalid_operation", "memory": "Test memory"}
+
+        # Execute
+        result = setup_tool.run(input_params)
+
+        # Assertions
+        assert "error" in result
+        assert "Invalid mode 'invalid_operation'" in result["error"]
+
+
+class TestMemoryToolIntegration:
+    """Integration test cases."""
+
+    @patch("tools.MemoryTool.ThreadContext.get_data")
+    @patch("tools.MemoryTool.get_vector_store")
+    @patch("tools.MemoryTool.uuid.uuid1")
+    def test_full_memory_lifecycle(
+        self,
+        mock_uuid,
+        mock_get_vector_store,
+        mock_get_data,
+        setup_tool,
+        mock_context_data,
+        mock_vector_store,
+    ):
+        """Test complete memory lifecycle: add, search, update, delete."""
+        # Setup mocks
+        mock_get_data.side_effect = lambda key, default=None: mock_context_data.get(
+            key, default
+        )
+        mock_get_vector_store.return_value = mock_vector_store
+        memory_id = "lifecycle_test_123"
+        mock_uuid.return_value = memory_id
+
+        # 1. Add memory
+        add_params = {"mode": "add", "memory": "Initial memory content"}
+        add_result = setup_tool.run(add_params)
+        assert "result" in add_result
+        assert "Memory added" in add_result["result"]
+
+        # 2. Search memory
+        mock_doc = MagicMock()
+        mock_doc.page_content = "Initial memory content"
+        mock_doc.metadata = {"memory_id": memory_id}
+        mock_vector_store.similarity_search.return_value = [mock_doc]
+
+        search_params = {"mode": "search", "query": "initial", "k": 1}
+        search_result = setup_tool.run(search_params)
+        assert "result" in search_result
+        assert "Initial memory content" in search_result["result"]
+
+        # 3. Update memory
+        mock_vector_store.get.return_value = {
+            "ids": [memory_id],
+            "metadatas": [{"user_id": "test_user_456", "memory_id": memory_id}],
+        }
+
+        update_params = {
+            "mode": "update",
+            "memory_id": memory_id,
+            "memory": "Updated content",
+        }
+        update_result = setup_tool.run(update_params)
+        assert "result" in update_result
+        assert "Memory updated" in update_result["result"]
+
+        # 4. Delete memory
+        delete_params = {"mode": "delete", "memory_id": memory_id}
+        delete_result = setup_tool.run(delete_params)
+        assert "result" in delete_result
+        assert "Memory with memory_id" in delete_result["result"]
+        assert "deleted" in delete_result["result"]

--- a/tools/MemoryTool.py
+++ b/tools/MemoryTool.py
@@ -1,0 +1,407 @@
+"""
+Memory Tool for Etendo Copilot Toolpack
+
+This module provides a comprehensive tool for managing memories in a vector database
+using Chroma as the backend storage. It supports CRUD operations (Create, Read, Update, Delete)
+for user-specific memories with vector similarity search capabilities.
+
+Author: Etendo Software
+Version: 1.0
+"""
+
+import uuid
+from typing import Optional, Type
+
+from langchain_chroma import Chroma
+from langchain_core.documents import Document
+from langsmith import traceable
+
+from copilot.core.threadcontext import ThreadContext
+from copilot.core.tool_input import ToolField, ToolInput
+from copilot.core.tool_wrapper import ToolWrapper
+from copilot.core.utils import copilot_debug
+from copilot.core.vectordb_utils import (
+    get_chroma_settings,
+    get_embedding,
+    get_vector_db_path,
+)
+
+
+class MemoryToolInput(ToolInput):
+    """
+    Input schema for the MemoryTool.
+
+    This class defines the expected input parameters for memory operations including
+    mode selection, memory content, search queries, and memory identifiers.
+
+    Attributes:
+        mode (str): Operation mode - must be 'add', 'search', 'update', or 'delete'
+        memory (Optional[str]): Memory content to store or update (required for add/update modes)
+        query (Optional[str]): Search query string for finding similar memories (required for search mode)
+        memory_id (Optional[str]): Unique identifier for targeting specific memories (required for update/delete modes)
+        k (int): Maximum number of search results to return, only applies to search mode (default: 3)
+    """
+
+    mode: str = ToolField(
+        description="Operation mode. Must be one of: 'add', 'search', 'update', or 'delete'."
+    )
+    memory: Optional[str] = ToolField(
+        description="The memory content to store or update. Required for 'add' and 'update' modes.",
+        default=None,
+    )
+    query: Optional[str] = ToolField(
+        description="Search query string to find similar memories. Required for 'search' mode.",
+        default=None,
+    )
+    memory_id: Optional[str] = ToolField(
+        description="Unique identifier of the memory to modify or remove. Required for 'update' and 'delete' modes.",
+        default=None,
+    )
+    k: int = ToolField(
+        description="Maximum number of search results to return. Only used in 'search' mode.",
+        default=3,
+    )
+
+
+@traceable
+def validate_and_process_input(input_params):
+    """
+    Validate and process input parameters for memory operations.
+
+    This function validates the input mode and extracts all necessary parameters
+    for the memory operation. It ensures the mode is valid and returns all
+    parameters in a structured format.
+
+    Args:
+        input_params (dict): Dictionary containing input parameters from the user
+
+    Returns:
+        tuple: A tuple containing (mode, memory, query, memory_id, k)
+
+    Raises:
+        ValueError: If the mode is not one of the supported operations
+
+    Example:
+        >>> params = {"mode": "add", "memory": "Test memory", "k": 5}
+        >>> mode, memory, query, memory_id, k = validate_and_process_input(params)
+    """
+    mode = input_params.get("mode")
+    memory = input_params.get("memory")
+    query = input_params.get("query")
+    memory_id = input_params.get("memory_id")
+    k = input_params.get("k", 3)
+
+    if mode not in ["add", "search", "update", "delete"]:
+        raise ValueError(
+            f"Invalid mode '{mode}'. Use 'add', 'search', 'update', or 'delete'."
+        )
+
+    return mode, memory, query, memory_id, k
+
+
+def get_vector_store(kb_vectordb_id):
+    """
+    Initialize and return a Chroma vector database instance.
+
+    This function sets up a connection to the Chroma vector database using
+    the provided knowledge base vector database ID. It configures the database
+    with the appropriate embedding function and client settings.
+
+    Args:
+        kb_vectordb_id (str): Unique identifier for the knowledge base vector database
+
+    Returns:
+        Chroma: Configured Chroma vector database instance ready for operations
+
+    Example:
+        >>> vector_store = get_vector_store("assistant_123_memories")
+        >>> # vector_store is now ready for add/search/update/delete operations
+    """
+    db_path = get_vector_db_path(kb_vectordb_id)
+    db = Chroma(
+        persist_directory=db_path,
+        embedding_function=get_embedding(),
+        client_settings=get_chroma_settings(),
+    )
+    return db
+
+
+def delete(memory_id, user_id, vector_store):
+    """
+    Delete a specific memory from the vector database.
+
+    This function removes a memory document from the vector store based on the
+    provided memory ID. It first verifies that the memory exists and belongs
+    to the specified user before performing the deletion.
+
+    Args:
+        memory_id (str): Unique identifier of the memory to delete
+        user_id (str): ID of the user who owns the memory
+        vector_store (Chroma): Vector database instance to delete from
+
+    Returns:
+        dict: Result dictionary containing either success message or error
+              - On success: {"result": "Memory with memory_id {id} deleted for user_id {user}"}
+              - On error: {"error": "Error description"}
+
+    Example:
+        >>> result = delete("mem_123", "user_456", vector_store)
+        >>> if "result" in result:
+        ...     print("Memory deleted successfully")
+    """
+    if not memory_id:
+        return {"error": "The 'memory_id' parameter is required for 'delete' mode."}
+    current_docs = vector_store.get(ids=[memory_id])
+    if not current_docs["ids"] or current_docs["metadatas"][0]["user_id"] != user_id:
+        return {
+            "error": f"No memory found with memory_id {memory_id} for user_id {user_id}"
+        }
+    vector_store.delete(ids=[memory_id])
+    result = f"Memory with memory_id {memory_id} deleted for user_id {user_id}"
+    copilot_debug(f"Tool MemoryTool output: {result}")
+    return {"result": result}
+
+
+def update(memory, memory_id, user_id, vector_store):
+    """
+    Update an existing memory in the vector database.
+
+    This function modifies the content of an existing memory document while
+    preserving its metadata. It verifies that the memory exists and belongs
+    to the specified user before performing the update operation.
+
+    Args:
+        memory (str): New content for the memory
+        memory_id (str): Unique identifier of the memory to update
+        user_id (str): ID of the user who owns the memory
+        vector_store (Chroma): Vector database instance to update
+
+    Returns:
+        dict: Result dictionary containing either success message or error
+              - On success: {"result": "Memory updated for user_id {user}: {content} (memory_id: {id})"}
+              - On error: {"error": "Error description"}
+
+    Example:
+        >>> result = update("Updated memory content", "mem_123", "user_456", vector_store)
+        >>> if "result" in result:
+        ...     print("Memory updated successfully")
+    """
+    if not memory_id or not memory:
+        return {
+            "error": "Both 'memory_id' and 'memory' are required for 'update' mode."
+        }
+    current_docs = vector_store.get(ids=[memory_id])
+    if not current_docs["ids"] or current_docs["metadatas"][0]["user_id"] != user_id:
+        return {
+            "error": f"No memory found with memory_id {memory_id} for user_id {user_id}"
+        }
+    updated_doc = Document(
+        page_content=memory, metadata={"user_id": user_id, "memory_id": memory_id}
+    )
+    vector_store.update_documents(ids=[memory_id], documents=[updated_doc])
+    result = f"Memory updated for user_id {user_id}: {memory} (memory_id: {memory_id})"
+    copilot_debug(f"Tool MemoryTool output: {result}")
+    return {"result": result}
+
+
+def search(k, query, user_id, vector_store):
+    """
+    Search for memories using vector similarity search.
+
+    This function performs a semantic search over the user's memories using
+    vector similarity. It returns the most relevant memories based on the
+    query string, filtered by the user ID.
+
+    Args:
+        k (int): Maximum number of results to return
+        query (str): Search query to find similar memories
+        user_id (str): ID of the user whose memories to search
+        vector_store (Chroma): Vector database instance to search in
+
+    Returns:
+        dict: Result dictionary containing either search results or error
+              - On success: {"result": "Formatted list of matching memories with IDs"}
+              - On no results: {"result": "No memories found message"}
+              - On error: {"error": "Error description"}
+
+    Example:
+        >>> result = search(3, "important meeting", "user_456", vector_store)
+        >>> if "result" in result:
+        ...     print(f"Found memories: {result['result']}")
+    """
+    if not query:
+        return {"error": "The 'query' parameter is required for 'search' mode."}
+    results = vector_store.similarity_search(
+        query=query, k=k, filter={"user_id": user_id}
+    )
+    if not results:
+        result = f"No memories found for user_id {user_id} with query: {query}"
+    else:
+        result = "\n".join(
+            [
+                f"- {doc.page_content} (memory_id: {doc.metadata['memory_id']})"
+                for doc in results
+            ]
+        )
+    copilot_debug(f"Tool MemoryTool output: {result}")
+    return {"result": result}
+
+
+def add(memory, user_id, vector_store):
+    """
+    Add a new memory to the vector database.
+
+    This function creates a new memory document with the provided content and
+    associates it with the specified user. A unique memory ID is automatically
+    generated using UUID1.
+
+    Args:
+        memory (str): Content of the memory to store
+        user_id (str): ID of the user who owns the memory
+        vector_store (Chroma): Vector database instance to add to
+
+    Returns:
+        dict: Result dictionary containing either success message or error
+              - On success: {"result": "Memory added for user_id {user}: {content} (memory_id: {id})"}
+              - On error: {"error": "Error description"}
+
+    Example:
+        >>> result = add("Remember to call John tomorrow", "user_456", vector_store)
+        >>> if "result" in result:
+        ...     print("Memory added successfully")
+    """
+    if not memory:
+        return {"error": "The 'memory' parameter is required for 'add' mode."}
+    memory_id = str(uuid.uuid1())
+    document = Document(
+        page_content=memory, metadata={"user_id": user_id, "memory_id": memory_id}
+    )
+    vector_store.add_documents(documents=[document], ids=[memory_id])
+    result = f"Memory added for user_id {user_id}: {memory} (memory_id: {memory_id})"
+    copilot_debug(f"Tool MemoryTool output: {result}")
+    return {"result": result}
+
+
+def read_context_variables():
+    """
+    Retrieve context variables from the current thread context.
+
+    This function extracts the assistant ID and user ID from the thread context,
+    which are required for memory operations. These values are used to create
+    user-specific vector stores and ensure data isolation.
+
+    Returns:
+        tuple: A tuple containing (assistant_id, user_id)
+               - assistant_id (str|None): Unique identifier for the assistant
+               - user_id (str|None): Unique identifier for the user (AD User ID)
+
+    Example:
+        >>> assistant_id, user_id = read_context_variables()
+        >>> if assistant_id and user_id:
+        ...     print(f"Context loaded: Assistant {assistant_id}, User {user_id}")
+    """
+    assistant_id = ThreadContext.get_data("assistant_id", None)
+    user_id = ThreadContext.get_data("ad_user_id", None)
+    return assistant_id, user_id
+
+
+class MemoryTool(ToolWrapper):
+    """
+    A comprehensive tool for managing user memories in a vector database.
+
+    This class provides a complete interface for memory management operations
+    including adding, searching, updating, and deleting memories. Each memory
+    is associated with a specific user and stored in a vector database for
+    efficient similarity-based retrieval.
+
+    The tool uses Chroma as the vector database backend and maintains user
+    isolation by filtering operations based on user IDs. Memory operations
+    are traced for debugging and monitoring purposes.
+
+    Supported Operations:
+        - add: Create a new memory with automatic ID generation
+        - search: Find memories using vector similarity search
+        - update: Modify existing memory content
+        - delete: Remove a specific memory
+
+    Attributes:
+        name (str): Tool identifier "MemoryTool"
+        description (str): Human-readable description of tool capabilities
+        args_schema (Type[ToolInput]): Input validation schema class
+
+    Example:
+        >>> tool = MemoryTool()
+        >>> params = {"mode": "add", "memory": "Important meeting notes"}
+        >>> result = tool.run(params)
+        >>> print(result["result"])
+    """
+
+    name: str = "MemoryTool"
+    description: str = (
+        "A comprehensive tool for managing user memories in a vector database. "
+        "Supports four operation modes: "
+        "'add' (requires 'memory' field), "
+        "'search' (requires 'query' field, optional 'k' for result limit), "
+        "'update' (requires 'memory_id' and 'memory' fields), "
+        "'delete' (requires 'memory_id' field). "
+        "All operations are user-scoped and use memory_id for specific memory identification."
+    )
+    args_schema: Type[ToolInput] = MemoryToolInput
+
+    @traceable
+    def run(self, input_params, *args, **kwargs):
+        """
+        Execute the memory operation based on the provided parameters.
+
+        This method serves as the main entry point for all memory operations.
+        It validates inputs, retrieves context variables, initializes the vector
+        store, and delegates to the appropriate operation function.
+
+        Args:
+            input_params (dict): Dictionary containing operation parameters
+                - mode (str): Operation type ('add', 'search', 'update', 'delete')
+                - memory (str, optional): Memory content for add/update
+                - query (str, optional): Search query for search operations
+                - memory_id (str, optional): Memory identifier for update/delete
+                - k (int, optional): Maximum search results (default: 3)
+            *args: Additional positional arguments (unused)
+            **kwargs: Additional keyword arguments (unused)
+
+        Returns:
+            dict: Operation result containing either success data or error message
+                  - On success: {"result": "Operation-specific success message"}
+                  - On error: {"error": "Detailed error description"}
+
+        Raises:
+            ValueError: If required context variables are missing
+            Exception: For any other operation failures
+
+        Example:
+            >>> params = {"mode": "search", "query": "meeting notes", "k": 5}
+            >>> result = tool.run(params)
+            >>> if "error" not in result:
+            ...     print(f"Search results: {result['result']}")
+        """
+        try:
+            mode, memory, query, memory_id, k = validate_and_process_input(input_params)
+            assistant_id, user_id = read_context_variables()
+            if not assistant_id or not user_id:
+                # throw exception
+                raise ValueError("assistant_id or ad_user_id not found in Payload.")
+            vector_store = get_vector_store(kb_vectordb_id=assistant_id + "_memories")
+            if mode == "add":
+                return add(memory, user_id, vector_store)
+
+            elif mode == "search":
+                return search(k, query, user_id, vector_store)
+
+            elif mode == "update":
+                return update(memory, memory_id, user_id, vector_store)
+
+            elif mode == "delete":
+                return delete(memory_id, user_id, vector_store)
+
+        except Exception as e:
+            errmsg = f"Error in MemoryTool: {str(e)}"
+            copilot_debug(errmsg)
+            return {"error": errmsg}


### PR DESCRIPTION
This commit introduces the MemoryTool class, which provides a comprehensive interface for managing user memories in a vector database. It supports CRUD operations (Create, Read, Update, Delete) and includes a test suite that covers all functionalities with proper mocking of dependencies.