### PR TITLE
Feature ETP-3874: Migrate javax to jakarta and update Hibernate 6 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ repositories {
     maven {
         url "https://maven.pkg.github.com/etendosoftware/com.etendoerp.copilot.extensions"
     }
+
+    maven {
+       url "https://repo.futit.cloud/repository/maven-snapshots/"
+    }
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -54,5 +54,5 @@ repositories {
 dependencies {
     implementation('com.etendoerp:copilot:3.1.0')
     implementation('com.github.jsqlparser:jsqlparser:5.1')
-    implementation('com.etendoerp.platform:etendo-core:[26.1.0,26.2.0)')
+    implementation('com.etendoerp.platform:etendo-core:[27.1.0,27.2.0)')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ repositories {
 * Ex: implementation "com.sun.mail:javax.mail:1.6.2"
 */
 dependencies {
-    implementation('com.etendoerp:copilot:3.1.0')
+    implementation('com.etendoerp:copilot:3.1.1-SNAPSHOT')
     implementation('com.github.jsqlparser:jsqlparser:5.1')
     implementation('com.etendoerp.platform:etendo-core:[27.1.0,27.2.0)')
 }

--- a/jenkinsExtraModules.txt
+++ b/jenkinsExtraModules.txt
@@ -1,1 +1,6 @@
-git@github.com:etendosoftware/com.etendoerp.docker.git,git@github.com:etendosoftware/com.etendoerp.task.git,git@github.com:etendosoftware/com.etendoerp.etendorx.git,git@github.com:etendosoftware/com.etendoerp.asyncprocess.git,git@github.com:etendosoftware/com.etendoerp.openapi.git,git@github.com:etendosoftware/com.etendoerp.telemetry.git
+git@github.com:etendosoftware/com.etendoerp.docker.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.task.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.etendorx.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.asyncprocess.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.openapi.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.telemetry.git|feature/ETP-3674-Y27>{CORE_BRANCH}

--- a/jenkinsExtraModules.txt
+++ b/jenkinsExtraModules.txt
@@ -1,6 +1,1 @@
-git@github.com:etendosoftware/com.etendoerp.docker.git|feature/ETP-3674-Y27>{CORE_BRANCH}
-git@github.com:etendosoftware/com.etendoerp.task.git|feature/ETP-3674-Y27>{CORE_BRANCH}
-git@github.com:etendosoftware/com.etendoerp.etendorx.git|feature/ETP-3674-Y27>{CORE_BRANCH}
-git@github.com:etendosoftware/com.etendoerp.asyncprocess.git|feature/ETP-3674-Y27>{CORE_BRANCH}
-git@github.com:etendosoftware/com.etendoerp.openapi.git|feature/ETP-3674-Y27>{CORE_BRANCH}
-git@github.com:etendosoftware/com.etendoerp.telemetry.git|feature/ETP-3674-Y27>{CORE_BRANCH}
+git@github.com:etendosoftware/com.etendoerp.docker.git,git@github.com:etendosoftware/com.etendoerp.task.git,git@github.com:etendosoftware/com.etendoerp.etendorx.git,git@github.com:etendosoftware/com.etendoerp.asyncprocess.git,git@github.com:etendosoftware/com.etendoerp.openapi.git,git@github.com:etendosoftware/com.etendoerp.telemetry.git

--- a/src-db/database/sourcedata/AD_MODULE.xml
+++ b/src-db/database/sourcedata/AD_MODULE.xml
@@ -6,7 +6,7 @@
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <AD_ORG_ID><![CDATA[0]]></AD_ORG_ID>
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <ISACTIVE><![CDATA[Y]]></ISACTIVE>
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <NAME><![CDATA[Tool Pack]]></NAME>
-<!--DAD8E003446345E1BD052DC3539DAA53-->  <VERSION><![CDATA[3.1.0]]></VERSION>
+<!--DAD8E003446345E1BD052DC3539DAA53-->  <VERSION><![CDATA[3.1.0-SNAPSHOT]]></VERSION>
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <DESCRIPTION><![CDATA[Specialized tool set for Etendo Copilot]]></DESCRIPTION>
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <HELP><![CDATA[Tool Pack is a module for Etendo Copilot that provides a set of specialized tools available to any assistant. It adds specific functionalities to enhance performance and expand capabilities, making assistants more versatile and effective.]]></HELP>
 <!--DAD8E003446345E1BD052DC3539DAA53-->  <TYPE><![CDATA[M]]></TYPE>

--- a/src/com/etendoerp/copilot/toolpack/SqlToHqlInitializer.java
+++ b/src/com/etendoerp/copilot/toolpack/SqlToHqlInitializer.java
@@ -2,16 +2,16 @@ package com.etendoerp.copilot.toolpack;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.dialect.function.SQLFunction;
 import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.query.sqm.function.SqmFunctionDescriptor;
 import org.hibernate.type.StandardBasicTypes;
 import org.openbravo.dal.core.SQLFunctionRegister;
 
 public class SqlToHqlInitializer implements SQLFunctionRegister {
 
   @Override
-  public Map<String, SQLFunction> getSQLFunctions() {
-    Map<String, SQLFunction> sqlFunctions = new HashMap<>();
+  public Map<String, SqmFunctionDescriptor> getSQLFunctions() {
+    Map<String, SqmFunctionDescriptor> sqlFunctions = new HashMap<>();
 
     sqlFunctions.put("etcotp_sim_search",
         new StandardSQLFunction("etcotp_sim_search", StandardBasicTypes.BIG_DECIMAL));

--- a/src/com/etendoerp/copilot/toolpack/webhooks/ExecSQL.java
+++ b/src/com/etendoerp/copilot/toolpack/webhooks/ExecSQL.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.jettison.json.JSONArray;
-import org.hibernate.criterion.Restrictions;
+import org.openbravo.dal.service.Restrictions;
 import org.openbravo.base.exception.OBException;
 import org.openbravo.base.model.Entity;
 import org.openbravo.dal.core.OBContext;

--- a/src/com/etendoerp/copilot/toolpack/webhooks/ReadOAuthToken.java
+++ b/src/com/etendoerp/copilot/toolpack/webhooks/ReadOAuthToken.java
@@ -3,7 +3,7 @@ package com.etendoerp.copilot.toolpack.webhooks;
 import java.util.Date;
 import java.util.Map;
 
-import org.hibernate.criterion.Restrictions;
+import org.openbravo.dal.service.Restrictions;
 import org.openbravo.dal.service.OBDal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/com/etendoerp/copilot/toolpack/webhooks/SimSearch.java
+++ b/src/com/etendoerp/copilot/toolpack/webhooks/SimSearch.java
@@ -111,9 +111,8 @@ public class SimSearch extends BaseWebhookService {
 
     WSResult wsResult = new WSResult();
     JSONArray arrayResponse;
-    String whereOrderByClause2 = String.format(
-        " as p where  etcotp_sim_search(:tableName, p.id, :searchTerm) > %s order by etcotp_sim_search(:tableName, p.id, :searchTerm) desc ",
-        Integer.parseInt(minSimilarityPercent));
+    String whereOrderByClause2 = " as p where function('etcotp_sim_search', :tableName, p.id, :searchTerm) > :minSimilarityPercent "
+        + "order by function('etcotp_sim_search', :tableName, p.id, :searchTerm) desc ";
     Set<Entity> readableEntities = OBContext.getOBContext().getEntityAccessChecker().getReadableEntities();
     Entity entity = readableEntities.stream().filter(e -> e.getName().equals(entityName)).findFirst().orElse(
         null);
@@ -124,7 +123,7 @@ public class SimSearch extends BaseWebhookService {
     }
     Class<? extends BaseOBObject> entityClass = Class.forName(entity.getClassName()).asSubclass(BaseOBObject.class);
     arrayResponse = searchEntities(whereOrderByClause2, result.searchTerm, qtyResults,
-        entityClass, entity.getTableName()
+        entityClass, entity.getTableName(), new BigDecimal(minSimilarityPercent)
     );
     wsResult.setStatus(Status.OK);
     wsResult.setData(arrayResponse);
@@ -180,12 +179,14 @@ public class SimSearch extends BaseWebhookService {
    *     If an error occurs while processing the JSON data.
    */
   private static <T extends BaseOBObject> JSONArray searchEntities(String whereOrderByClause2,
-      String searchTerm, int qtyResults, Class<T> entityClass, String tableName) throws JSONException {
+      String searchTerm, int qtyResults, Class<T> entityClass, String tableName,
+      BigDecimal minSimilarityPercent) throws JSONException {
 
     OBQuery<T> searchQuery = OBDal.getInstance().createQuery(entityClass, whereOrderByClause2);
 
     searchQuery.setNamedParameter("tableName", StringUtils.lowerCase(tableName));
     searchQuery.setNamedParameter("searchTerm", searchTerm);
+    searchQuery.setNamedParameter("minSimilarityPercent", minSimilarityPercent);
     searchQuery.setMaxResult(qtyResults);
     var resultList = searchQuery.list();
     JSONArray arrayResponse = new JSONArray();

--- a/src/com/etendoerp/copilot/toolpack/webhooks/SimSearch.java
+++ b/src/com/etendoerp/copilot/toolpack/webhooks/SimSearch.java
@@ -9,9 +9,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.hibernate.ScrollMode;
-import org.hibernate.ScrollableResults;
-import org.hibernate.query.Query;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.structure.BaseOBObject;
 import org.openbravo.dal.core.OBContext;
@@ -216,10 +213,10 @@ public class SimSearch extends BaseWebhookService {
    */
   private static BigDecimal calcSimilarityPercent(String id, String searchTerm, String tableName) {
     String sql = String.format("select etcotp_sim_search('%s', '%s', '%s')", tableName, id, searchTerm);
-    Query query = OBDal.getInstance().getSession().createSQLQuery(sql);
-    ScrollableResults scroll = query.scroll(ScrollMode.FORWARD_ONLY);
-    scroll.next();
-    BigDecimal percent = (BigDecimal) scroll.get(0);
+    BigDecimal percent = OBDal.getInstance().getSession()
+        .createNativeQuery(sql, BigDecimal.class)
+        .setMaxResults(1)
+        .uniqueResult();
     return percent.setScale(4, RoundingMode.HALF_UP);
   }
 


### PR DESCRIPTION
## Summary

- Migrate `javax.*` imports to `jakarta.*` across all source files
- Update Hibernate 5 API usages to Hibernate 6 (e.g. `org.hibernate.criterion.Restrictions` → `org.openbravo.dal.service.Restrictions`)
- Bump `etendo-core` dependency range to `[27.1.0, 27.2.0)` in `build.gradle`

## Related

- Epic: ETP-2587
- Feature: ETP-3874